### PR TITLE
remove username/password, add in path and docs

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,5 +1,9 @@
 
 config = {
-    'USERNAME' : 'yourusername@gmail.com',
-    'PASSWORD' : 'yourpassword',
+    'PATH' : 'C:\\google-drive-data\\',
+    # all docs must be shared with client_email as defined in the json file for oauth2
+    'DOCS'     : [
+      {"doc":"My 1st doc title"},
+      {"doc":"My 2nd doc title"} 
+      ],
     }


### PR DESCRIPTION
username/password are no longer appropriate for oauth2 as of April 2015. Furthermore, path and docs are hard-coded into the python code and should be in the config file instead, so I have made those changes.
