### PR TITLE
updated to use oauth2

### DIFF
--- a/download-spreadsheet.py
+++ b/download-spreadsheet.py
@@ -3,19 +3,20 @@ import gspread
 import urllib
 import codecs
 from config import config
-
+import json
+from oauth2client.client import SignedJwtAssertionCredentials
 
 #config
-username = config['USERNAME']
-password = config['PASSWORD']
-docs = [
-    {"doc": "My 1st Spreadsheet Name"},
-    {"doc":"My 2nd Spreadsheet Name"} 
-    ]
+docs = config['DOCS']
 
+# open the json file with the oath2 credentials
+json_key = json.load(open('oauth2_credentials.json'))
+scope = ['https://spreadsheets.google.com/feeds']
 
 # login first
-client = gspread.login(username, password)
+credentials = SignedJwtAssertionCredentials(json_key['client_email'], json_key['private_key'], scope)
+
+client = gspread.authorize(credentials)
 
 #process doc list
 for doc in docs:


### PR DESCRIPTION
Updated to use oauth2 (separate oauth2_credentials.json not supplied, will be different and private for each user) instead of username/password, which was decom'd in April 2015.

Also updated to get output path and document list from config.py.
